### PR TITLE
Typesafe Authentication DSL

### DIFF
--- a/proposals/0006-auth-3.5.md
+++ b/proposals/0006-auth-3.5.md
@@ -130,9 +130,7 @@ runtime.
 
 # User Journey
 
-This section walks through Option A — the typesafe extension module — step by
-step. Each step builds on the previous one. Option B (typed provider DSL) is
-described in the [next section](#alternative-typed-provider-dsl).
+This section walks through Option A.
 
 ## Step 1 — Define Your Principal
 
@@ -289,7 +287,30 @@ routing {
 }
 ```
 
-## Step 8 — Error Handling
+## Step 8 — Multiple Schemes
+
+A route can accept more than one scheme. The principal type is the nearest
+common supertype of all schemes' principal types:
+
+```kotlin
+interface AppUser : Principal { val email: String }
+data class JwtUser(override val email: String, val sub: String) : AppUser
+data class SessionUser(override val email: String) : AppUser
+
+val JwtScheme = createAuthScheme<JwtUser>("my-jwt")
+val SessionScheme = createAuthScheme<SessionUser>("my-session")
+
+routing {
+    authenticateWith(JwtScheme, SessionScheme) {
+        get("/profile") {
+            val user: AppUser = principal
+            call.respond(user.email)
+        }
+    }
+}
+```
+
+## Step 9 — Error Handling
 
 Customize unauthorized and forbidden responses:
 
@@ -468,7 +489,7 @@ class TimeBoundCache<P : Any, ID : Any>(
 ## Scope Types
 
 ```kotlin
-interface AuthenticatedScope<P : Any> {
+interface AuthenticatedScope<P> {
     context(ctx: RoutingContext)
     val principal: P
 }
@@ -481,25 +502,28 @@ interface RoleBasedScope<P : Any, R : AuthRole> : AuthenticatedScope<P> {
 
 ## Route Builders
 
+All overloads accept one or more schemes via `vararg`. When multiple schemes are
+provided, `P` is inferred as the nearest common supertype.
+
 ```kotlin
 fun <P : Any> Route.authenticateWith(
-    scheme: AuthScheme<P>,
+    vararg schemes: AuthScheme<out P>,
     build: context(AuthenticatedScope<P>) Route.() -> Unit
 ): Route
 
 fun <P : Any, R : AuthRole> Route.authenticateWith(
-    scheme: RoleBasedAuthScheme<P, R>,
+    vararg schemes: RoleBasedAuthScheme<out P, R>,
     roles: Set<R> = emptySet(),
     build: context(RoleBasedScope<P, R>) Route.() -> Unit
 ): Route
 
 fun <P : Any> Route.authenticateWithOptional(
-    scheme: AuthScheme<P>,
+    vararg schemes: AuthScheme<out P>,
     build: context(AuthenticatedScope<P?>) Route.() -> Unit
 ): Route
 
 fun <B : Any, P : B, AP : B> Route.authenticateWith(
-    scheme: AnonymousAuthScheme<P, AP>,
+    vararg schemes: AnonymousAuthScheme<out P, out AP>,
     build: context(AuthenticatedScope<B>) Route.() -> Unit
 ): Route
 ```
@@ -699,9 +723,7 @@ Composable predicates can be applied inside `authenticateWith` without defining
 val emailVerified = claimCheck<JwtUserPrincipal> { it.emailVerified == true }
 val hasReadScope = claimCheck<JwtUserPrincipal> { "read:documents" in it.scopes }
 
-authenticateWith(MyJwt) {
-    require(emailVerified and hasReadScope)
-
+authenticateWith(MyJwt, claims = emailVerified and hasReadScope) {
     get("/documents") {
         call.respond(principal.email)
     }

--- a/proposals/0006-auth-3.5.md
+++ b/proposals/0006-auth-3.5.md
@@ -1,536 +1,709 @@
-|             |                                                                                  |
-|-------------|----------------------------------------------------------------------------------|
-| Feature     | Typesafe Authentication & OpenID Connect Plugin                                  |
-| Submitted   | 2026-03-23                                                                       |
-| Accepted    | No                                                                               |
-| Issue       | https://youtrack.jetbrains.com/issue/KTOR-9266/Improve-Auth-in-Ktor              |
-| Preceded by |                                                                                  |
-| Followed by |                                                                                  |
+|             |                                                                     |
+| ----------- | ------------------------------------------------------------------- |
+| Feature     | Typesafe Authentication DSL                                         |
+| Submitted   | 2026-03-23                                                          |
+| Accepted    | No                                                                  |
+| Issue       | https://youtrack.jetbrains.com/issue/KTOR-9266/Improve-Auth-in-Ktor |
+| Preceded by |                                                                     |
+| Followed by | [0007-openid-connect-auth-3.5](0007-openid-connect-auth-3.5.md)     |
 
 ### Contents
 
 1. [Summary](#summary)
 2. [Motivation](#motivation)
-3. [Current Solutions](#current-solutions)
-4. [Design Overview](#design-overview)
-5. [Design Details](#design-details)
-6. [Technical Details](#technical-details)
-7. [Drawbacks](#drawbacks)
-8. [Advantages](#advantages)
-9. [Open Questions](#open-questions)
-10. [Future Directions](#future-directions)
+3. [Packages](#packages)
+4. [The Problem Today](#the-problem-today)
+5. [User Journey](#user-journey)
+6. [Alternative: Typed Provider DSL](#alternative-typed-provider-dsl)
+7. [API Reference](#api-reference)
+8. [Technical Details](#technical-details)
+9. [Ktor-Defined vs User-Defined](#ktor-defined-vs-user-defined)
+10. [Advantages](#advantages)
+11. [Drawbacks](#drawbacks)
+12. [Open Questions](#open-questions)
+13. [Future Directions](#future-directions)
 
 <hr />
 
 # Summary
 
-This proposal introduces role-based authorization in Ktor's core auth module, a typesafe authentication DSL with non-nullable principals, and a first-class OpenID Connect plugin for Ktor 3.5.0. Role support (`AuthRole`, `roles { }` extractor, `call.roles()`) is added directly to `ktor-server-auth` so it works with every authentication provider. The typesafe DSL (`requireAuth`, `optionalAuth`, `AuthScheme<T, R>`) with vararg multi-scheme support is delivered as a separate `ktor-server-typesafe-auth` module of pure extension functions, compiled with Kotlin 2.4.0 for context parameters. Together these changes eliminate the most common boilerplate. All new APIs ship under `@KtorExperimental` to allow community feedback before stabilisation.
+The core idea is to encode more information in auth schemes at the type level —
+principal type, role model, anonymous fallback — so the compiler enforces
+correctness across the entire auth pipeline, not just at the point of
+`call.principal<T>()`.
+
+This proposal presents two equal alternatives:
+
+**Option A: Typesafe extension to the current system.** A new
+`ktor-server-typesafe-auth` module (requires Kotlin 2.4.0 context parameters)
+adds `AuthScheme<P>`, `RoleBasedAuthScheme<P, R>`, `AnonymousAuthScheme<P, AP>`,
+and `authenticateWith(...)` on top of the existing `ktor-server-auth` providers.
+The current auth DSL remains unchanged; users opt in by creating typed scheme
+wrappers.
+
+**Option B: Typed provider DSL replacing the current one.** Existing provider
+builders gain typed overloads (`jwt<P>(name) { ... }`, `basic<P>(name) { ... }`,
+etc.) that return `AuthScheme<P>` directly. This eliminates the separate scheme
+creation step and could become the primary auth API in Ktor 4, with the untyped
+builders preserved for backward compatibility.
 
 # Motivation
 
-1. **No OpenID Connect support.**
+1. **Nullable principals in mandatory auth.** `call.principal<T>()` remains `T?`
+   even inside authenticated routes, forcing defensive null checks everywhere.
+2. **RBAC is not universal.** Many applications rely on claims or policy checks
+   without a role model; a global roles API does not fit all use cases.
+3. **Global role access is a footgun.** Role APIs should exist only when
+   role-capable schemes are explicitly configured, not on every route.
+4. **Scheme setup should be simple.** Users should not need to create manual
+   `object` implementations for every scheme.
+5. **String coupling between providers and routes.** The provider name passed to
+   `jwt("my-jwt")` and `authenticate("my-jwt")` is an unverified string — typos
+   and type mismatches are caught only at runtime.
 
-2. **Principals are always nullable (KTOR-8594).** Even inside a mandatory `authenticate { }` block, `call.principal<T>()` returns `T?`. This forces every route handler to perform a null check or `!!`, adding noise and masking the actual guarantee that the pipeline provides.
+# Packages
 
-3. **No built-in role/permission support.** Nearly every real application needs role-based access control.
-
-# Current Solutions
-
-### OpenID Connect
-
-Low-level API proposal https://github.com/ktorio/ktor/pull/5339:
+Both alternatives require the existing `ktor-server-auth` module and introduce a
+new `ktor-server-typesafe-auth` module. The split differs slightly between
+Option A and Option B.
 
 ```kotlin
-val config = httpClient.fetchOpenIdConfiguration("https://accounts.google.com")
-install(Authentication) {
-    jwt {
-        validate { credential ->
-            val userId = credential.subject
-            database.findUser(userId)?.let { UserPrincipal(it) }
-        }
-        jwk {
-            openIdConfig = config
-            audience = "my-app-client-id"
-        }
-    }
+dependencies {
+    // Existing module — unchanged.
+    // Provides the Authentication plugin, provider builders (jwt, basic, bearer,
+    // session, oauth, form, digest), and the Principal interface.
+    implementation("io.ktor:ktor-server-auth:$ktorVersion")
+
+    // Provides the jwt() provider builder, JWT verification, and JWK support.
+    // Not the only supported provider — used for examples below
+    implementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")
+
+    // New module — requires Kotlin 2.4.0 (context parameters).
+    // Provides AuthScheme<P>, RoleBasedAuthScheme<P, R>, AnonymousAuthScheme<P, AP>,
+    // factory functions (createAuthScheme, withRoles, orAnonymous), and the
+    // authenticateWith / authenticateWithOptional route builders with typed scopes.
+    implementation("io.ktor:ktor-server-typesafe-auth:$ktorVersion")
+
+    // Not required — used in examples below for sharing schemes across modules.
+    implementation("io.ktor:ktor-server-dependency-injection:$ktorVersion")
 }
 ```
 
-### Nullable Principals
+**Option A** keeps all new types and factories in `ktor-server-typesafe-auth`.
+The existing `ktor-server-auth` module is untouched.
 
-Even when authentication is mandatory, every handler must deal with nullability:
+**Option B** moves `AuthScheme<P>` and the typed provider overloads
+(`jwt<P>(name) { ... }`, etc.) into `ktor-server-auth` itself, since they have
+no dependency on context parameters. Only `authenticateWith` (which uses context
+parameters for the scope) stays in `ktor-server-typesafe-auth`.
 
-```kotlin
-authenticate {
-    get("/profile") {
-        val principal = call.principal<UserPrincipal>()
-            ?: return@get call.respond(HttpStatusCode.Unauthorized)
-        // ... use principal
-    }
-}
-```
+# The Problem Today
 
-# Design Overview
+### Nullable Principal in Mandatory Auth
 
-This proposal addresses the pain points through three interconnected features:
-
-| Pain Point | Proposed Solution |
-|---|---|
-| No role support | `AuthRole` interface, `roles { }` extractor on every provider, `call.roles()` accessor — all in core `ktor-server-auth` |
-| Nullable principals | `requireAuth(scheme, roles) { }` routing DSL with non-null `principal` and typed `roles` vals via context parameters, and vararg multi-scheme support — in `ktor-server-typesafe-auth` |
-| OpenID Connect boilerplate | First-class `install(OpenIdConnect) { }` plugin with auto-discovery and sensible defaults — in `ktor-server-auth-openid` |
-
-All new APIs are annotated `@KtorExperimental`.
-
-# Design Details
-
-## 1. OpenID Connect Plugin
-
-### Minimal Setup (Resource Server)
-
-A resource server that only validates JWTs from an OpenID Connect provider:
-
-```kotlin
-install(OpenIdConnect) {
-    jwk(
-        issuer = "https://accounts.google.com",
-        audience = "my-app-client-id"
-    )
-}
-```
-
-The plugin automatically:
-- Fetches `/.well-known/openid-configuration` from the issuer
-- Configures a JWK provider from the discovered `jwks_uri`
-- Validates the issuer claim
-- Extracts standard OpenID Connect claims into `OpenIdConnectPrincipal`
-
-### Full Setup (Authorization Server with OAuth2 + Sessions)
-
-An application that also handles login/logout flows:
-
-```kotlin
-install(OpenIdConnect) {
-    jwk(
-        issuer = "https://accounts.google.com", 
-        audience = "my-app-client-id"
-    )
-    
-    oauth("https://accounts.google.com", clientId, clientSecret) {
-        scopes = listOf("openid", "profile", "email")
-        
-        // URI configuration — defaults are provided, override as needed
-        redirectUri { path("oidc", "redirect") }
-        loginUri { path("oidc", "login") }
-        logoutUri { path("oidc", "logout") }
-        
-        // Session configuration
-        session("OPENID_SESSION") {
-            cookie.secure = true
-            cookie.httpOnly = true
-            cookie.extensions["SameSite"] = "lax"
-        }
-        
-        // Lifecycle callbacks
-        onSuccess { principal ->
-            call.sessions.set(principal)
-            call.respondRedirect("/")
-        }
-        
-        onFailure {
-            call.respond(HttpStatusCode.Unauthorized)
-        }
-        
-        // Opt-in to token refresh
-        refresh {
-            refreshUri { path("oidc", "refresh") }
-            autoRefresh = true
-            refreshThresholdSeconds = 300
-        }
-    }
-}
-```
-
-### `OpenIdConnectPrincipal` and Claims
-
-`OpenIdConnectPrincipal` provides typed access to standard OpenID Connect claims:
-
-```kotlin
-@Serializable
-open class OpenIdConnectPrincipal(
-    val idToken: String,
-    val accessToken: String? = null,
-    val refreshToken: String? = null,
-    val userInfo: UserInfo,
-) {
-    @Serializable
-    class UserInfo(
-        val subject: String,
-        val name: String? = null,
-        val email: String? = null,
-        val emailVerified: Boolean? = null,
-        val picture: String? = null,
-        val givenName: String? = null,
-        val familyName: String? = null,
-        // ... other standard OIDC claims
-        val claims: Map<String, Any?> = emptyMap()
-    )
-}
-```
-
-Custom claims are accessible via a typed DSL:
-
-```kotlin
-fun OpenIdConnectPrincipal.customField(): Long? =
-    userInfo.claims.getTyped("x-custom-field")
-
-inline fun <reified T> Map<String, Any?>.getTyped(key: String): T? =
-    this[key] as? T
-```
-
-This replaces the current verbose `credential.payload.getClaim(...).let { ... }` pattern.
-
-### Auto-Discovery Lifecycle
-
-The OpenID Connect discovery call is made asynchronously during application startup.
-1. Launched in `Application.coroutineScope` at plugin install time
-2. Wait inside `ApplicationModulesLoaded` handler, fail before start
-
-The `HttpClient` used for discovery defaults to a preconfigured internal client, but can be overridden:
-
-```kotlin
-install(OpenIdConnect) {
-    httpClient = myCustomClient
-    // ...
-}
-```
-
-### Named Security Schemes
-
-Each provider is automatically named for OpenAPI compatibility:
-
-- JWK-only provider: `"google"` (derived from config key)
-- OAuth provider: `"google-oauth"`
-- Combined JWK + session: `"google-jwt"`
-
-Custom names can be provided:
-
-```kotlin
-jwk("https://accounts.google.com") {
-    name = "google-resource"
-    // ...
-}
-```
-
-## 2. Role-Based Authorization (`ktor-server-auth`)
-
-Role support is added directly to Ktor's core `ktor-server-auth` module, making it available to **all** authentication providers without additional dependencies.
-
-### `AuthRole` Interface
-
-Roles are modeled as an interface, allowing users to use enums, sealed classes, or any implementation:
-
-```kotlin
-interface AuthRole {
-    val name: String
-}
-```
-
-Typical usage with an enum:
-
-```kotlin
-enum class Role : AuthRole {
-    User, Admin, Moderator;
-}
-```
-
-### Role Extraction on Authentication Providers
-
-A `roles { }` function is added to `AuthenticationProvider.Config` — the base class for all providers. Every built-in and custom provider supports role extraction automatically:
-
-```kotlin
-install(Authentication) {
-    jwt("my-jwt") {
-        validate { credential -> UserPrincipal(credential.payload) }
-        roles { principal: UserPrincipal ->
-            principal.tokenRoles
-                .mapNotNull { name -> Role.entries.find { it.name == name } }
-                .toSet()
-        }
-    }
-
-    session<SessionUser>("web-session") {
-        validate { session -> session }
-        roles { principal: SessionUser ->
-            database.rolesFor(principal.id)
-        }
-    }
-
-    bearer("api-key") {
-        authenticate { credential -> ApiKeyPrincipal(credential.token) }
-        roles { principal: ApiKeyPrincipal ->
-            database.permissionsFor(principal.keyId)
-        }
-    }
-}
-```
-
-The extractor runs once after successful validation. The result is stored in the authentication context alongside the principal. If the extractor is not provided, roles are null.
-
-### `call.roles()` — Low-Level Accessor
-
-After authentication, resolved roles are available via `call.roles()`:
+Even inside an `authenticate { }` block the principal is nullable, forcing a
+defensive check on every route:
 
 ```kotlin
 authenticate("my-jwt") {
     get("/profile") {
-        val principal = call.principal<UserPrincipal>()  // T? (existing API, unchanged)
-        val roles = call.roles()                          // Set<AuthRole>? (new)
+        val principal = call.principal<UserPrincipal>()
+            ?: return@get call.respond(HttpStatusCode.Unauthorized)
+        call.respond(principal.email)
     }
 }
 ```
 
-## 3. Typesafe Authentication DSL (`ktor-server-typesafe-auth`)
+### Ad-hoc Role / Claim Authorization
 
-The typesafe DSL is delivered as a **separate module** `ktor-server-typesafe-auth` so it can be compiled with a newer Kotlin version (targeting 2.4.0 for context parameters). This module provides pure extension functions that build on top of the core `ktor-server-auth` APIs (`authenticate`, `call.principal<T>()`, `call.roles()`).
+Most projects implement custom route wrappers or inline checks against claims
+and principals. There is no typed distinction between principal-only and
+role-capable flows, and nothing prevents accessing role APIs on routes where no
+role resolution is configured.
 
-### `AuthScheme<T, R>` — Typed Authentication Scheme
+### String-Coupled Provider Names
 
-Authentication schemes carry their principal type and role type as generic parameters. Both are defined once at scheme declaration and inferred at every call site:
+The link between the provider (`jwt("my-jwt") { ... }`) and the route guard
+(`authenticate("my-jwt") { ... }`) is a plain string. A typo or a mismatch
+between the expected principal type and the actual one is only caught at
+runtime.
+
+# User Journey
+
+This section walks through Option A — the typesafe extension module — step by
+step. Each step builds on the previous one. Option B (typed provider DSL) is
+described in the [next section](#alternative-typed-provider-dsl).
+
+## Step 1 — Define Your Principal
 
 ```kotlin
-interface AuthScheme<T : Any, R : AuthRole> {
-    val name: String
-}
+data class JwtUserPrincipal(
+    val userId: String,
+    val email: String
+) : Principal
 ```
 
-Users define their schemes as objects:
+## Step 2 — Configure the Auth Provider
+
+Standard Ktor auth — nothing changes here:
 
 ```kotlin
-object GoogleJwt : AuthScheme<OpenIdConnectPrincipal, Role> {
-    override val name = "google-jwt"
-}
-
-object ApiKey : AuthScheme<ApiKeyPrincipal, ApiPermission> {
-    override val name = "api-key"
-}
-```
-
-The `R` parameter ensures that `requireAuth(GoogleJwt, roles = listOf(Role.Admin))` is checked at compile time — passing an `ApiPermission` where `Role` is expected is a type error.
-
-### `requireAuth` — Non-Nullable Principal with Integrated Roles
-
-A single routing DSL function that guarantees a non-null principal and optionally enforces roles — eliminating the nesting of separate `authenticate` + `withRole` blocks:
-
-```kotlin
-routing {
-    // Scheme-based — principal type inferred from GoogleJwt
-    requireAuth(GoogleJwt) {
-        get("/dashboard") {
-            val user: OpenIdConnectPrincipal = principal  // non-null, type inferred from T
-            val userRoles: Set<Role> = roles               // typed to R, resolved by core extractor
-
-            if (Role.Admin in userRoles) {
-                call.respond(adminDashboard(user))
-            } else {
-                call.respond(userDashboard(user))
+fun Application.security() {
+    install(Authentication) {
+        jwt("my-jwt") {
+            realm = "my-app"
+            verifier(jwkProvider, issuer) {
+                acceptLeeway(3)
+            }
+            validate { credential ->
+                JwtUserPrincipal(
+                    userId = credential.payload.subject,
+                    email = credential.payload.getClaim("email").asString()
+                )
             }
         }
     }
+}
+```
 
-    // Scheme-based + role gate — 403 if user lacks the role, no extra nesting
-    requireAuth(GoogleJwt, roles = listOf(Role.Admin, Role.Moderator)) {
-        put("/content/{id}/moderate") { /* ... */ }
-    }
+## Step 3 — Create a Typed Scheme
 
-    // Multi-scheme — accept either Google JWT or GitHub OAuth
-    // Both schemes share a common principal supertype (UserPrincipal)
-    requireAuth(GoogleJwt, GithubOAuth) {
+Bind the principal type to the provider name once:
+
+```kotlin
+val MyJwt = createAuthScheme<JwtUserPrincipal>("my-jwt")
+```
+
+## Step 4 — Protect Routes
+
+Use `authenticateWith` instead of `authenticate`. Inside the block `principal`
+is non-null and correctly typed — no cast, no `?: return`:
+
+```kotlin
+routing {
+    authenticateWith(MyJwt) {
         get("/profile") {
-            val user: UserPrincipal = principal  // common ancestor, non-null
-            call.respond(userProfile(user))
+            val user: JwtUserPrincipal = principal
+            call.respond(user.email)
         }
-    }
-
-    // Multi-scheme with role gate
-    requireAuth(GoogleJwt, GithubOAuth, roles = listOf(Role.Admin)) {
-        delete("/users/{id}") { /* ... */ }
     }
 }
 ```
 
-When multiple schemes are provided, Kotlin infers `T` and `R` as the least upper bound (common ancestor) of the scheme type parameters. For example, if `GoogleJwt : AuthScheme<OidcPrincipal, Role>` and `GithubOAuth : AuthScheme<OAuthPrincipal, Role>` where both principal types extend `UserPrincipal`, then `principal` is typed as `UserPrincipal`.
+## Step 5 — Add Roles (Opt-in)
 
-`requireAuth` internally:
-1. Wraps the route in `authenticate(...)` using the scheme name(s)
-2. Installs a route-scoped interceptor that extracts the principal and makes it available as a non-null `val` via Kotlin context parameters
-3. If roles are specified, checks `call.roles()` against the required set — responds 403 Forbidden on mismatch
-4. Returns 401 Unauthorized if authentication fails (configurable)
-
-### Signature
+Define a role model and compose a role-capable scheme from the base scheme:
 
 ```kotlin
-fun <T : Any, R : AuthRole> Route.requireAuth(
-    vararg schemes: AuthScheme<out T, out R>,
-    roles: List<R> = emptyList(),
-    build: Route.() -> Unit
+enum class Role : AuthRole {
+    User, Admin, Moderator
+}
+
+fun Application.security() {
+    val roleService: RoleService by dependencies
+
+    val MyJwt = createAuthScheme<JwtUserPrincipal>("my-jwt")
+
+    val RoleBasedJwt = MyJwt.withRoles { principal ->
+        roleService.resolveRoles(principal.userId)
+    }
+
+    dependencies.provide { RoleBasedJwt }
+}
+```
+
+`roles` is available only inside a `RoleBasedAuthScheme` scope — it does not
+exist on principal-only routes:
+
+```kotlin
+routing {
+    authenticateWith(RoleBasedJwt, roles = setOf(Role.Admin)) {
+        get("/admin") {
+            val userRoles: Set<Role> = roles
+            call.respond(userRoles.map { it.name })
+        }
+    }
+}
+```
+
+Alternatively, create a role-based scheme directly without a base scheme:
+
+```kotlin
+val RoleBasedJwt = createRoleBasedAuthScheme<JwtUserPrincipal, Role>("my-jwt") { principal ->
+    roleService.resolveRoles(principal.userId)
+}
+```
+
+Or add a caching strategy to avoid resolving roles on every call:
+
+```kotlin
+val RoleBasedJwtCached = MyJwt.withRoles(
+    cacheStrategy = RolesCacheStrategy.PerKey { principal -> principal.userId }
+) { principal ->
+    roleService.resolveRoles(principal.userId)
+}
+```
+
+## Step 6 — Add Anonymous Fallback (Opt-in)
+
+When some routes should serve both authenticated and unauthenticated users with
+different behavior, compose an anonymous-capable scheme:
+
+```kotlin
+interface MyPrincipal
+
+class AuthenticatedUser(val userId: String) : MyPrincipal
+class AnonymousUser : MyPrincipal
+
+val MyAuth = createAuthScheme<AuthenticatedUser>("google-jwt")
+val AnonymousAuth = MyAuth.orAnonymous { call -> AnonymousUser() }
+```
+
+Inside `authenticateWith`, the principal type is the nearest common supertype of
+the authenticated and anonymous principal types:
+
+```kotlin
+routing {
+    authenticateWith(AnonymousAuth) {
+        get("/feedback") {
+            val user: MyPrincipal = principal
+            call.respond(user)
+        }
+    }
+}
+```
+
+## Step 7 — Optional Authentication
+
+When a route should work with or without authentication (principal becomes
+nullable):
+
+```kotlin
+routing {
+    authenticateWithOptional(MyJwt) {
+        get("/me") {
+            val p: JwtUserPrincipal? = principal
+            call.respond(p?.email ?: "anonymous")
+        }
+    }
+}
+```
+
+## Step 8 — Error Handling
+
+Customize unauthorized and forbidden responses:
+
+```kotlin
+routing {
+    authenticateWith(
+        RoleBasedJwt,
+        roles = setOf(Role.Admin),
+        onUnauthorized = { call -> call.respond(HttpStatusCode.Unauthorized) },
+        onForbidden = { call, requiredRoles -> call.respond(HttpStatusCode.Forbidden) },
+    ) {
+        get("/admin") {
+            call.respond(principal.email)
+        }
+    }
+}
+```
+
+# Alternative: Typed Provider DSL
+
+Option B collapses the two-step "configure provider then create scheme" into one
+by adding typed overloads to the existing provider builders. The untyped API
+remains for backward compatibility.
+
+## Typed Overload Pattern
+
+Current provider builders return `Unit` inside `install(Authentication)`:
+
+```kotlin
+install(Authentication) {
+    jwt("my-jwt") { validate { ... } }
+}
+```
+
+Typed overloads return `AuthScheme<P>` directly — the `validate` block's return
+type determines `P`:
+
+```kotlin
+install(Authentication) {
+    val MyJwt: AuthScheme<JwtUserPrincipal> = jwt<JwtUserPrincipal>("my-jwt") {
+        validate { credential ->
+            JwtUserPrincipal(
+                userId = credential.payload.subject,
+                email = credential.payload.getClaim("email").asString()
+            )
+        }
+    }
+}
+```
+
+## Full Example
+
+```kotlin
+fun Application.security() {
+    install(Authentication) {
+        val MyJwt = jwt<JwtUserPrincipal>("my-jwt") {
+            realm = "my-app"
+            verifier(jwkProvider, issuer) { acceptLeeway(3) }
+            validate { credential ->
+                JwtUserPrincipal(
+                    userId = credential.payload.subject,
+                    email = credential.payload.getClaim("email").asString()
+                )
+            }
+        }
+
+        dependencies.provide { MyJwt }
+    }
+}
+
+fun Application.module() {
+    val MyJwt: AuthScheme<JwtUserPrincipal> by dependencies
+
+    routing {
+        authenticateWith(MyJwt) {
+            get("/profile") {
+                call.respond(principal.email)
+            }
+        }
+    }
+}
+```
+
+## Applicable Providers
+
+Typed overloads apply to all existing provider builders:
+
+- `jwt<P>(name) { ... }` — JWT validation
+- `basic<P>(name) { ... }` — HTTP Basic
+- `bearer<P>(name) { ... }` — Bearer token
+- `form<P>(name) { ... }` — Form-based login
+- `session<P>(name) { ... }` — Session-backed auth
+- `oauth<P>(name) { ... }` — OAuth flows
+- `digest<P>(name) { ... }` — HTTP Digest
+
+## Option A vs Option B
+
+| Aspect                        | Option A (separate module)                  | Option B (typed overloads)                      |
+| ----------------------------- | ------------------------------------------- | ----------------------------------------------- |
+| Changes to `ktor-server-auth` | None                                        | Adds typed overloads to each provider builder   |
+| Scheme creation               | Explicit `createAuthScheme<P>(name)` step   | Returned from provider builder, no extra step   |
+| String coupling risk          | Name must match between provider and scheme | Eliminated — scheme is produced by the provider |
+| Composability                 | `.withRoles { }`, `.orAnonymous { }`        | Same — returned schemes are fully composable    |
+| Backward compatibility        | Fully additive, no API changes              | Additive overloads, can cause issues?           |
+
+# API Reference
+
+## Core Interfaces
+
+```kotlin
+interface AuthScheme<P : Any> {
+    val name: String
+}
+
+interface AuthRole {
+    val name: String
+}
+
+interface RoleBasedAuthScheme<P : Any, R : AuthRole> : AuthScheme<P> {
+    suspend fun resolveRoles(call: ApplicationCall, principal: P): Set<R>
+}
+
+interface AnonymousAuthScheme<P : Any, AP : Any> : AuthScheme<P> {
+    suspend fun createAnonymous(call: ApplicationCall): AP
+}
+```
+
+## Factory Functions
+
+```kotlin
+fun <P : Any> createAuthScheme(name: String): AuthScheme<P>
+
+fun <P : Any, AP : Any> createAuthScheme(
+    name: String,
+    anonymousPrincipal: suspend (ApplicationCall) -> AP
+): AnonymousAuthScheme<P, AP>
+
+fun <P : Any, R : AuthRole, ID : Any> createRoleBasedAuthScheme(
+    name: String,
+    cacheStrategy: RolesCacheStrategy<P, ID> = RolesCacheStrategy.PerCall(),
+    rolesResolver: suspend ApplicationCall.(P) -> Set<R>
+): RoleBasedAuthScheme<P, R>
+```
+
+## Composition Helpers
+
+```kotlin
+fun <P : Any, R : AuthRole, ID : Any> AuthScheme<P>.withRoles(
+    cacheStrategy: RolesCacheStrategy<P, ID> = RolesCacheStrategy.PerCall(),
+    resolve: suspend ApplicationCall.(P) -> Set<R>
+): RoleBasedAuthScheme<P, R>
+
+fun <P : Any, AP : Any> AuthScheme<P>.orAnonymous(
+    factory: suspend (ApplicationCall) -> AP
+): AnonymousAuthScheme<P, AP>
+```
+
+## Cache Strategy
+
+```kotlin
+interface RolesCacheStrategy<P : Any, ID : Any> {
+    object PerCall<P : Any, ID : Any> : RolesCacheStrategy<P, ID>
+    class PerKey<P : Any, ID : Any>(idResolve: (P) -> ID) : RolesCacheStrategy<P, ID>
+}
+```
+
+The interface is open, so users can provide a custom implementation:
+
+```kotlin
+class TimeBoundCache<P : Any, ID : Any>(
+    private val ttl: Duration,
+    private val idResolve: (P) -> ID
+) : RolesCacheStrategy<P, ID>
+```
+
+## Scope Types
+
+```kotlin
+interface AuthenticatedScope<P : Any> {
+    context(ctx: RoutingContext)
+    val principal: P
+}
+
+interface RoleBasedScope<P : Any, R : AuthRole> : AuthenticatedScope<P> {
+    context(ctx: RoutingContext)
+    val roles: Set<R>
+}
+```
+
+## Route Builders
+
+```kotlin
+fun <P : Any> Route.authenticateWith(
+    scheme: AuthScheme<P>,
+    build: context(AuthenticatedScope<P>) Route.() -> Unit
+): Route
+
+fun <P : Any, R : AuthRole> Route.authenticateWith(
+    scheme: RoleBasedAuthScheme<P, R>,
+    roles: Set<R> = emptySet(),
+    build: context(RoleBasedScope<P, R>) Route.() -> Unit
+): Route
+
+fun <P : Any> Route.authenticateWithOptional(
+    scheme: AuthScheme<P>,
+    build: context(AuthenticatedScope<P?>) Route.() -> Unit
+): Route
+
+fun <B : Any, P : B, AP : B> Route.authenticateWith(
+    scheme: AnonymousAuthScheme<P, AP>,
+    build: context(AuthenticatedScope<B>) Route.() -> Unit
 ): Route
 ```
 
-### Principal and Roles via Context Parameters
-
-With context parameters, user-defined functions can access the principal and roles directly in scope:
-
-```kotlin
-context(principal: OpenIdConnectPrincipal, ctx: RoutingContext)
-suspend fun userProfile(): UserProfile {
-    return UserProfile(
-        name = principal.userInfo.name,
-        email = principal.userInfo.email
-    )
-}
-
-context(ctx: RoutingContext)
-suspend fun isAdmin(): Boolean =
-    Role.Admin in roles
-```
-
-### Unauthorized Handler
-
-When a user lacks the required role, the server responds with 403 Forbidden by default. This is configurable:
-
-```kotlin
-requireAuth(GoogleJwt, roles = listOf(Role.Admin)) {
-    onUnauthorized { call, requiredRoles ->
-        call.respond(HttpStatusCode.Forbidden, "Requires: ${requiredRoles.joinToString()}")
-    }
-    get("/admin/users") { /* ... */ }
-}
-```
-
-The JWK provider checks (in order):
-1. `Authorization: Bearer <token>` header
-2. Session cookie with the configured name
-
-This supports both API clients (Bearer) and browser sessions (cookie) on the same endpoints. For OpenAPI documentation, both schemes are emitted under a single security requirement using an `OR` composition.
-
 # Technical Details
 
-## Module Structure
+## Behavior
 
-The proposal spans three layers:
+1. Wrap route with `authenticate(...)` for scheme names.
+2. Resolve non-null principal for mandatory variant.
+3. For anonymous-capable schemes, if authentication fails, create an anonymous
+   principal via `createAnonymous(call)` instead of returning 401.
+4. Return 401 on auth failure (or call `onUnauthorized` when provided).
+5. For role-based overload, resolve roles only for role-based schemes.
+6. If `roles` is non-empty, return 403 on mismatch (or call `onForbidden` when
+   provided).
+7. Apply optional `transformPrincipal` before exposing route-scope principal.
+8. Expose typed `principal` and (role-based overload only) typed `roles`.
 
-- **`ktor-server-auth`** (existing module, extended) — `AuthRole` interface, `roles { }` extractor on `AuthenticationProvider.Config`, `call.roles()` accessor. Compiled with the same Kotlin version as Ktor core. All authentication providers gain role support with no additional dependencies.
-- **`ktor-server-typesafe-auth`** (new module) — `AuthScheme<T, R>`, `requireAuth` / `optionalAuth` with vararg multi-scheme support, non-null `principal` val, typed `roles` val via context parameters. Compiled with a **newer Kotlin version** (targeting 2.4.0). This module is pure extension functions — no plugin install required. It depends on `ktor-server-auth` but not on `ktor-server-auth-openid`.
-- **`ktor-server-auth-openid`** (new module) — The OpenID Connect plugin. Compiled with the same Kotlin version as Ktor core. Configures JWK, OAuth, and session providers via the core `Authentication` plugin. Provides `withOidc` shorthand when `ktor-server-typesafe-auth` is also on the classpath.
+## Context Parameters
 
-## Plugin Architecture
+`ktor-server-typesafe-auth` is compiled with Kotlin 2.4.0 and uses context
+parameters natively. The scope object is constructed once at route-build time,
+but property access resolves per-call via `RoutingContext`. Type safety comes
+from binding `P` and `R` to the scheme's type parameters — `roles` is
+inaccessible in a principal-only scope, and `principal` is typed to the scheme's
+`P`.
 
-The `OpenIdConnect` plugin is a standard Ktor `BaseApplicationPlugin` that internally:
-1. Launches async discovery for each issuer
-2. Registers JWK and OAuth authentication providers via the `Authentication` plugin
-3. If OAuth is configured, installs `Sessions` and sets up login/callback/refresh/logout routes
-
-## Core Role Extraction Implementation
-
-When `roles { }` is configured on an `AuthenticationProvider.Config`, the extractor runs immediately after a successful `validate` call. The resolved set is stored in the authentication context alongside the principal:
-
-```kotlin
-val ResolvedRolesKey = AttributeKey<Set<AuthRole>>("ResolvedRoles")
-```
-
-`call.roles()` reads from this attribute:
-
-```kotlin
-fun ApplicationCall.roles(): Set<AuthRole> =
-    attributes.getOrNull(ResolvedRolesKey) ?: emptySet()
-```
-
-This is part of `ktor-server-auth` and works in any `authenticate { }` block.
-
-## `requireAuth` Implementation
-
-`requireAuth` is a pure extension function in `ktor-server-typesafe-auth` that:
-1. Wraps the route in `authenticate(...)` using the scheme name(s) from the vararg
-2. Installs a route-scoped interceptor that extracts the principal via `call.principal<T>()`
-3. If roles were specified, checks `call.roles()` against the required set (returns 403 on mismatch)
-4. Makes the principal available as a Kotlin context parameter
-
-Typesafe `principal` and `roles` are exposed as dynamic `val` properties that narrow the core types:
+## Implementation Sketch
 
 ```kotlin
-context(ctx: RoutingContext)
-val <T : Any> principal: T get() = ctx.call.principal<T>()!!
+private class AuthenticatedScopeImpl<P : Any> : AuthenticatedScope<P> {
+    context(ctx: RoutingContext)
+    override val principal: P
+        get() = requireNotNull(ctx.call.principal())
+}
 
-context(ctx: RoutingContext)
-val <R : AuthRole> roles: Set<R> get() = ctx.call.roles() as Set<R>
+private class RoleBasedScopeImpl<P : Any, R : AuthRole> : RoleBasedScope<P, R> {
+    context(ctx: RoutingContext)
+    override val principal: P
+        get() = requireNotNull(ctx.call.principal())
+
+    context(ctx: RoutingContext)
+    override val roles: Set<R>
+        get() = ctx.call.attributes[ResolvedRolesKey] as Set<R>
+}
 ```
 
-Since `ktor-server-typesafe-auth` is compiled with Kotlin 2.4.0, it uses context parameters directly — no fallback extension functions are needed.
+## Module Ownership
 
-## Interaction with Existing APIs
+- `ktor-server-typesafe-auth`
+  - `AuthScheme<P>`
+  - `RoleBasedAuthScheme<P, R>`
+  - `AnonymousAuthScheme<P, AP>`
+  - `createAuthScheme(name)`
+  - `createRoleBasedAuthScheme(...)`
+  - `withRoles { ... }`
+  - `orAnonymous { ... }`
+  - `authenticateWith(...)` / `authenticateWithOptional(...)`
 
-- `authenticate(...)` remains available for users who prefer the current API
-- `call.principal<T>()` continues to work (returns nullable)
-- `call.roles()` is new but returns an empty set if no `roles { }` extractor is configured, so existing code is unaffected
-- Existing `jwt { }`, `oauth { }`, `session { }` configurations are not affected — `roles { }` is optional
-- `OpenIdConnect` plugin internally uses these existing building blocks
+- `ktor-server-auth`
+  - unchanged core authentication primitives
+  - no `AuthRole`, no provider `roles { }`, no `call.roles()`
 
-## Dependencies
+# Ktor-Defined vs User-Defined
 
-**`ktor-server-auth`** (existing, extended) — no new dependencies. `AuthRole` and `roles { }` are additions to the existing module.
+## Ktor-Defined
 
-**`ktor-server-typesafe-auth`** depends on:
-- `ktor-server-auth` (for `call.principal<T>()`, `call.roles()`, `authenticate(...)`)
-- Kotlin 2.4.0+ (for context parameters)
+- Typed route entrypoints and overload rules
+- Execution order and status semantics (401 unauthenticated, 403 role mismatch
+  by default for role-based overload)
+- Anonymous principal fallback when scheme is anonymous-capable
+- Optional unauthorized/forbidden handlers
+- Role visibility only in role-based authentication scope
 
-**`ktor-server-auth-openid`** depends on:
-- `ktor-server-auth` (existing)
-- `ktor-server-auth-jwt` (existing)
-- `ktor-server-sessions` (existing)
-- `ktor-client-core` (for discovery HTTP calls)
-- `ktor-client-content-negotiation` + `ktor-serialization-kotlinx-json` (for discovery deserialization)
+## User-Defined
 
-# Drawbacks
-
-1. **Increased surface area.** Adding `requireAuth`, `AuthScheme<T, R>`, and the `OpenIdConnect` plugin introduces new concepts alongside existing ones. Users must learn when to use `authenticate` vs `requireAuth`.
-
-2. **Implicit defaults may conflict with Ktor's philosophy.** The OpenID Connect plugin makes decisions about URI paths, session names, and cookie settings. While these are overridable, implicit behaviour can surprise users accustomed to Ktor's explicit style.
-
-3. **Separate module requires newer Kotlin version.** The `ktor-server-typesafe-auth` module requires Kotlin 2.4.0 for context parameters.
-
-4. **Potential confusion with existing auth DSL.** Having both `authenticate { }` and `requireAuth { }` could confuse new users. Clear documentation and deprecation signals will be needed.
+- Principal model
+- Scheme names via `createAuthScheme(name)`
+- Role model (if needed)
+- Role resolution logic via `withRoles { ... }`
+- Anonymous principal factory via `orAnonymous { ... }`
+- Route policies and required roles
 
 # Advantages
 
-1. **Dramatically reduced boilerplate.** The OpenID Connect plugin reduces setup from 30+ lines of manual wiring to 5-10 lines. Typed principals eliminate null checks in every handler.
+1. **Compile-time principal safety.** `principal` is non-null and correctly
+   typed inside `authenticateWith` — no cast, no defensive `?: return` check.
+2. **No global RBAC footguns.** `roles` is only available inside a
+   `RoleBasedScope`, preventing accidental role access on routes where no role
+   resolution is configured.
+3. **(Mostly) Backwards compatible.** In Option A the existing
+   `ktor-server-auth` API is completely untouched. In Option B the typed
+   overloads are additive, could cause overloading issues.
+4. **Composable.** Role and anonymous capabilities layer on top of a base scheme
+   via `.withRoles { ... }` and `.orAnonymous { ... }` — no subclassing or
+   manual wiring needed.
+5. **Minimal boilerplate.** Factory functions (`createAuthScheme`,
+   `createRoleBasedAuthScheme`) replace manual `object` declarations and
+   interface implementations.
+6. **Scope-aware API surface.** Context parameters restrict the available APIs
+   to what the scheme supports: principal-only scopes expose `principal`,
+   role-based scopes additionally expose `roles`.
 
-2. **Enforces best practices.** Auto-discovery, httpOnly session cookies, secure defaults, and stateless JWT validation guide users toward secure implementations without requiring deep security knowledge.
+# Drawbacks
 
-3. **Type safety prevents bugs.** Enum/interface-based roles catch typos at compile time. Non-null principals eliminate an entire class of runtime errors.
-
-4. **Composable, layered design.** Roles work with any provider via core `ktor-server-auth` alone. Users who want non-null principals and vararg multi-scheme support add `ktor-server-typesafe-auth`. Users who want OpenID Connect add `ktor-server-auth-openid`. Each layer is independently useful.
-
-5. **`@KtorExperimental` provides a safe feedback period.**
+1. More API surface in `ktor-server-typesafe-auth`.
+2. Role checks require wrapping schemes with `withRoles`.
+3. Users needing shared role policies across many schemes may need additional
+   composition helpers.
+4. Requires Kotlin 2.4.0 for context parameters, which limits adoption until
+   compiler support is stable and widely available.
 
 # Open Questions
 
-1. **How far should defaults go?** The OpenID Connect plugin can provide default URIs for redirect, login, logout, and refresh. Should these require explicit opt-in, or is it acceptable to provide sensible defaults? The design review leaned toward requiring explicit enabling for features like auto-refresh.
-
-2. **Session + Bearer in a single provider vs named providers.** The design review concluded that multiple named schemes are better for OpenAPI documentation. Should dual-auth be the default, or should it require explicit configuration?
-
-3. **Anonymous user support.** Should anonymous sessions be part of this proposal or deferred? Lazy session creation (to avoid Redis cost) and anonymous-to-authenticated transitions need more design work.
-
-4. **`AuthRole` and `AuthScheme<T, R>` — interface vs sealed interface vs abstract class?** Both are currently interfaces. Should `AuthScheme<T, R>` be an abstract class to enable storing `KClass<T>` and `KClass<R>` tokens for reification, or is the interface sufficient?
+1. Should role resolution failures default to fail-closed (403) or be
+   configurable per route/scheme?
+2. Should `withRoles` support caching hints (per-call / per-key) in its API?
+3. **TBD:** Should `transformPrincipal` results be cached? What happens when
+   `transformPrincipal` returns `null` — reject with 401?
+4. **TBD:** Should `onUnauthorized` / `onForbidden` be parameters of
+   `authenticateWith`, or defined inside the builder block?
+5. **TBD:** In `authenticateWithOptional`, should other schemes' principals be
+   rejected (forced `null`) if the specified scheme does not match?
 
 # Future Directions
 
-1. **Multi-provider federation.** Support multiple OpenID Connect providers (Google, GitHub, Apple) with a unified principal type and automatic provider selection based on the token's `iss` claim.
+The following ideas are **not part of this proposal**. They illustrate possible
+extensions that stay consistent with the patterns introduced above.
 
-2. **Token refresh.** Automatic token refresh before expiry, configurable via the OpenID Connect plugin.
+## 1. Policy / Attribute-Based Authorization
 
-3. **Anonymous user support.** Lazy anonymous sessions with smooth transition to authenticated sessions. This needs careful design around distributed session storage costs.
+Unlike flat role enums, policies are structured values with parameters that
+support attribute-based decisions depending on request context.
 
-4. **Scope-based authorization.** Extend the role-based system to support OAuth2 scopes, enabling fine-grained permission checks like `withScope("orders:read")`.
+```kotlin
+sealed interface PolicyDecision {
+    data object Allow : PolicyDecision
+    data class Deny(val reason: String) : PolicyDecision
+}
 
-5. **PKCE and advanced OAuth2 flows.** Support Proof Key for Code Exchange (PKCE) for public clients, device authorization grants, and other advanced OAuth2 flows within the OpenID Connect plugin.
+interface PolicyBasedAuthScheme<P : Any, Policy : Any> : AuthScheme<P> {
+    suspend fun evaluate(call: ApplicationCall, principal: P, policy: Policy): PolicyDecision
+}
+
+fun <P : Any, Policy : Any> AuthScheme<P>.withPolicy(
+    evaluate: suspend ApplicationCall.(P, Policy) -> PolicyDecision
+): PolicyBasedAuthScheme<P, Policy>
+```
+
+Usage — the policy value is passed per-route instead of a role set:
+
+```kotlin
+data class OwnerOnly(val documentId: String)
+
+val SecuredJwt = MyJwt.withPolicy<JwtUserPrincipal, OwnerOnly> { principal, policy ->
+    val doc = documentService.get(policy.documentId)
+    if (doc.ownerId == principal.userId) PolicyDecision.Allow
+    else PolicyDecision.Deny("Not the owner")
+}
+
+routing {
+    authenticateWith(SecuredJwt, policy = OwnerOnly(documentId = "123")) {
+        put("/documents/123") {
+            call.respond(principal.email)
+        }
+    }
+}
+```
+
+The same pattern works for external policy engines (OPA, Cedar) — the evaluator
+calls out to the engine inside `withPolicy`.
+
+## 2. Claim-Based Authorization Helpers
+
+For cases where a full role model is unnecessary and gating on JWT claims or
+scopes is sufficient:
+
+```kotlin
+fun interface ClaimCheck<P : Any> {
+    suspend fun check(principal: P): Boolean
+}
+
+infix fun <P : Any> ClaimCheck<P>.and(other: ClaimCheck<P>) = ClaimCheck<P> {
+    this@and.check(it) && other.check(it)
+}
+
+infix fun <P : Any> ClaimCheck<P>.or(other: ClaimCheck<P>) = ClaimCheck<P> {
+    this@or.check(it) || other.check(it)
+}
+```
+
+Composable predicates can be applied inside `authenticateWith` without defining
+`AuthRole` or `withRoles`:
+
+```kotlin
+val emailVerified = claimCheck<JwtUserPrincipal> { it.emailVerified == true }
+val hasReadScope = claimCheck<JwtUserPrincipal> { "read:documents" in it.scopes }
+
+authenticateWith(MyJwt) {
+    require(emailVerified and hasReadScope)
+
+    get("/documents") {
+        call.respond(principal.email)
+    }
+}
+```

--- a/proposals/0006-auth-3.5.md
+++ b/proposals/0006-auth-3.5.md
@@ -23,12 +23,10 @@
 <hr />
 
 # Summary
-[summary]: #summary
 
-This proposal introduces role-based authorization in Ktor's core auth module, a typesafe authentication DSL with non-nullable principals, and a first-class OpenID Connect plugin for Ktor 3.5.0. Role support (`AuthRole`, `roles { }` extractor, `call.roles()`) is added directly to `ktor-server-auth` so it works with every authentication provider. The typesafe DSL (`requireAuth`, `optionalAuth`, `AuthScheme<T, R>`) is delivered as a separate `ktor-server-auth-typesafe` module of pure extension functions, compiled with Kotlin 2.4.0 for context parameters. Together these changes eliminate the most common boilerplate. All new APIs ship under `@KtorExperimental` to allow community feedback before stabilisation.
+This proposal introduces role-based authorization in Ktor's core auth module, a typesafe authentication DSL with non-nullable principals, and a first-class OpenID Connect plugin for Ktor 3.5.0. Role support (`AuthRole`, `roles { }` extractor, `call.roles()`) is added directly to `ktor-server-auth` so it works with every authentication provider. The typesafe DSL (`requireAuth`, `optionalAuth`, `AuthScheme<T, R>`) with vararg multi-scheme support is delivered as a separate `ktor-server-typesafe-auth` module of pure extension functions, compiled with Kotlin 2.4.0 for context parameters. Together these changes eliminate the most common boilerplate. All new APIs ship under `@KtorExperimental` to allow community feedback before stabilisation.
 
 # Motivation
-[motivation]: #motivation
 
 1. **No OpenID Connect support.**
 
@@ -37,7 +35,6 @@ This proposal introduces role-based authorization in Ktor's core auth module, a 
 3. **No built-in role/permission support.** Nearly every real application needs role-based access control.
 
 # Current Solutions
-[current-solutions]: #current-solutions
 
 ### OpenID Connect
 
@@ -74,20 +71,18 @@ authenticate {
 ```
 
 # Design Overview
-[design-overview]: #design-overview
 
 This proposal addresses the pain points through three interconnected features:
 
 | Pain Point | Proposed Solution |
 |---|---|
 | No role support | `AuthRole` interface, `roles { }` extractor on every provider, `call.roles()` accessor — all in core `ktor-server-auth` |
-| Nullable principals | `requireAuth(scheme, roles) { }` routing DSL with non-null `principal()` and typed `roles()` via context parameters — in `ktor-server-auth-typesafe` |
+| Nullable principals | `requireAuth(scheme, roles) { }` routing DSL with non-null `principal` and typed `roles` vals via context parameters, and vararg multi-scheme support — in `ktor-server-typesafe-auth` |
 | OpenID Connect boilerplate | First-class `install(OpenIdConnect) { }` plugin with auto-discovery and sensible defaults — in `ktor-server-auth-openid` |
 
 All new APIs are annotated `@KtorExperimental`.
 
 # Design Details
-[design-details]: #design-details
 
 ## 1. OpenID Connect Plugin
 
@@ -295,9 +290,9 @@ authenticate("my-jwt") {
 }
 ```
 
-## 3. Typesafe Authentication DSL (`ktor-server-auth-typesafe`)
+## 3. Typesafe Authentication DSL (`ktor-server-typesafe-auth`)
 
-The typesafe DSL is delivered as a **separate module** `ktor-server-auth-typesafe` so it can be compiled with a newer Kotlin version. This module provides extension functions. It builds on top of the core `ktor-server-auth` APIs (`authenticate`, `call.principal<T>()`, `call.roles()`).
+The typesafe DSL is delivered as a **separate module** `ktor-server-typesafe-auth` so it can be compiled with a newer Kotlin version (targeting 2.4.0 for context parameters). This module provides pure extension functions that build on top of the core `ktor-server-auth` APIs (`authenticate`, `call.principal<T>()`, `call.roles()`).
 
 ### `AuthScheme<T, R>` — Typed Authentication Scheme
 
@@ -332,13 +327,13 @@ routing {
     // Scheme-based — principal type inferred from GoogleJwt
     requireAuth(GoogleJwt) {
         get("/dashboard") {
-            val principal: OpenIdConnectPrincipal = principal()  // non-null, type inferred from T
-            val userRoles: Set<Role> = roles()                   // typed to R, resolved by core extractor
+            val user: OpenIdConnectPrincipal = principal  // non-null, type inferred from T
+            val userRoles: Set<Role> = roles               // typed to R, resolved by core extractor
 
             if (Role.Admin in userRoles) {
-                call.respond(adminDashboard(principal))
+                call.respond(adminDashboard(user))
             } else {
-                call.respond(userDashboard(principal))
+                call.respond(userDashboard(user))
             }
         }
     }
@@ -347,20 +342,36 @@ routing {
     requireAuth(GoogleJwt, roles = listOf(Role.Admin, Role.Moderator)) {
         put("/content/{id}/moderate") { /* ... */ }
     }
+
+    // Multi-scheme — accept either Google JWT or GitHub OAuth
+    // Both schemes share a common principal supertype (UserPrincipal)
+    requireAuth(GoogleJwt, GithubOAuth) {
+        get("/profile") {
+            val user: UserPrincipal = principal  // common ancestor, non-null
+            call.respond(userProfile(user))
+        }
+    }
+
+    // Multi-scheme with role gate
+    requireAuth(GoogleJwt, GithubOAuth, roles = listOf(Role.Admin)) {
+        delete("/users/{id}") { /* ... */ }
+    }
 }
 ```
 
+When multiple schemes are provided, Kotlin infers `T` and `R` as the least upper bound (common ancestor) of the scheme type parameters. For example, if `GoogleJwt : AuthScheme<OidcPrincipal, Role>` and `GithubOAuth : AuthScheme<OAuthPrincipal, Role>` where both principal types extend `UserPrincipal`, then `principal` is typed as `UserPrincipal`.
+
 `requireAuth` internally:
 1. Wraps the route in `authenticate(...)` using the scheme name(s)
-2. Installs a route-scoped interceptor that extracts the principal and makes it available as non-null via Kotlin context parameters
+2. Installs a route-scoped interceptor that extracts the principal and makes it available as a non-null `val` via Kotlin context parameters
 3. If roles are specified, checks `call.roles()` against the required set — responds 403 Forbidden on mismatch
 4. Returns 401 Unauthorized if authentication fails (configurable)
 
-### Signature Overloads
+### Signature
 
 ```kotlin
 fun <T : Any, R : AuthRole> Route.requireAuth(
-    scheme: AuthScheme<T, R>,
+    vararg schemes: AuthScheme<out T, out R>,
     roles: List<R> = emptyList(),
     build: Route.() -> Unit
 ): Route
@@ -381,7 +392,7 @@ suspend fun userProfile(): UserProfile {
 
 context(ctx: RoutingContext)
 suspend fun isAdmin(): Boolean =
-    Role.Admin in roles()
+    Role.Admin in roles
 ```
 
 ### Unauthorized Handler
@@ -404,15 +415,14 @@ The JWK provider checks (in order):
 This supports both API clients (Bearer) and browser sessions (cookie) on the same endpoints. For OpenAPI documentation, both schemes are emitted under a single security requirement using an `OR` composition.
 
 # Technical Details
-[technical-details]: #technical-details
 
 ## Module Structure
 
 The proposal spans three layers:
 
 - **`ktor-server-auth`** (existing module, extended) — `AuthRole` interface, `roles { }` extractor on `AuthenticationProvider.Config`, `call.roles()` accessor. Compiled with the same Kotlin version as Ktor core. All authentication providers gain role support with no additional dependencies.
-- **`ktor-server-auth-typesafe`** (new module) — `AuthScheme<T, R>`, `requireAuth`, `optionalAuth`, non-null `principal()`, typed `roles()` via context parameters. Compiled with a **newer Kotlin version** (targeting 2.4.0). This module is pure extension functions — no plugin install required. It depends on `ktor-server-auth` but not on `ktor-server-auth-openid`.
-- **`ktor-server-auth-openid`** (new module) — The OpenID Connect plugin. Compiled with the same Kotlin version as Ktor core. Configures JWK, OAuth, and session providers via the core `Authentication` plugin. Provides `withOidc` shorthand when `ktor-server-auth-typesafe` is also on the classpath.
+- **`ktor-server-typesafe-auth`** (new module) — `AuthScheme<T, R>`, `requireAuth` / `optionalAuth` with vararg multi-scheme support, non-null `principal` val, typed `roles` val via context parameters. Compiled with a **newer Kotlin version** (targeting 2.4.0). This module is pure extension functions — no plugin install required. It depends on `ktor-server-auth` but not on `ktor-server-auth-openid`.
+- **`ktor-server-auth-openid`** (new module) — The OpenID Connect plugin. Compiled with the same Kotlin version as Ktor core. Configures JWK, OAuth, and session providers via the core `Authentication` plugin. Provides `withOidc` shorthand when `ktor-server-typesafe-auth` is also on the classpath.
 
 ## Plugin Architecture
 
@@ -440,21 +450,23 @@ This is part of `ktor-server-auth` and works in any `authenticate { }` block.
 
 ## `requireAuth` Implementation
 
-`requireAuth` is a pure extension function in `ktor-server-auth-typesafe` that:
-1. Wraps the route in `authenticate(...)` using the scheme name(s)
+`requireAuth` is a pure extension function in `ktor-server-typesafe-auth` that:
+1. Wraps the route in `authenticate(...)` using the scheme name(s) from the vararg
 2. Installs a route-scoped interceptor that extracts the principal via `call.principal<T>()`
 3. If roles were specified, checks `call.roles()` against the required set (returns 403 on mismatch)
 4. Makes the principal available as a Kotlin context parameter
 
-A typesafe `roles()` accessor narrows the core `Set<AuthRole>` to the scheme's role type `R`:
+Typesafe `principal` and `roles` are exposed as dynamic `val` properties that narrow the core types:
 
 ```kotlin
-context(principal: T, ctx: RoutingContext)
-@Suppress("UNCHECKED_CAST")
-fun <R : AuthRole> roles(): Set<R> = ctx.call.roles() as Set<R>
+context(ctx: RoutingContext)
+val <T : Any> principal: T get() = ctx.call.principal<T>()!!
+
+context(ctx: RoutingContext)
+val <R : AuthRole> roles: Set<R> get() = ctx.call.roles() as Set<R>
 ```
 
-Since `ktor-server-auth-typesafe` is compiled with Kotlin 2.4.0, it uses context parameters directly — no fallback extension functions are needed.
+Since `ktor-server-typesafe-auth` is compiled with Kotlin 2.4.0, it uses context parameters directly — no fallback extension functions are needed.
 
 ## Interaction with Existing APIs
 
@@ -468,7 +480,7 @@ Since `ktor-server-auth-typesafe` is compiled with Kotlin 2.4.0, it uses context
 
 **`ktor-server-auth`** (existing, extended) — no new dependencies. `AuthRole` and `roles { }` are additions to the existing module.
 
-**`ktor-server-auth-typesafe`** depends on:
+**`ktor-server-typesafe-auth`** depends on:
 - `ktor-server-auth` (for `call.principal<T>()`, `call.roles()`, `authenticate(...)`)
 - Kotlin 2.4.0+ (for context parameters)
 
@@ -480,18 +492,16 @@ Since `ktor-server-auth-typesafe` is compiled with Kotlin 2.4.0, it uses context
 - `ktor-client-content-negotiation` + `ktor-serialization-kotlinx-json` (for discovery deserialization)
 
 # Drawbacks
-[drawbacks]: #drawbacks
 
 1. **Increased surface area.** Adding `requireAuth`, `AuthScheme<T, R>`, and the `OpenIdConnect` plugin introduces new concepts alongside existing ones. Users must learn when to use `authenticate` vs `requireAuth`.
 
 2. **Implicit defaults may conflict with Ktor's philosophy.** The OpenID Connect plugin makes decisions about URI paths, session names, and cookie settings. While these are overridable, implicit behaviour can surprise users accustomed to Ktor's explicit style.
 
-3. **Separate module requires newer Kotlin version.** The `ktor-server-auth-typesafe` module requires context parameters.
+3. **Separate module requires newer Kotlin version.** The `ktor-server-typesafe-auth` module requires Kotlin 2.4.0 for context parameters.
 
 4. **Potential confusion with existing auth DSL.** Having both `authenticate { }` and `requireAuth { }` could confuse new users. Clear documentation and deprecation signals will be needed.
 
 # Advantages
-[advantages]: #advantages
 
 1. **Dramatically reduced boilerplate.** The OpenID Connect plugin reduces setup from 30+ lines of manual wiring to 5-10 lines. Typed principals eliminate null checks in every handler.
 
@@ -499,12 +509,11 @@ Since `ktor-server-auth-typesafe` is compiled with Kotlin 2.4.0, it uses context
 
 3. **Type safety prevents bugs.** Enum/interface-based roles catch typos at compile time. Non-null principals eliminate an entire class of runtime errors.
 
-4. **Composable, layered design.** Roles work with any provider via core `ktor-server-auth` alone. Users who want non-null principals add `ktor-server-auth-typesafe`. Users who want OpenID Connect add `ktor-server-auth-openid`. Each layer is independently useful.
+4. **Composable, layered design.** Roles work with any provider via core `ktor-server-auth` alone. Users who want non-null principals and vararg multi-scheme support add `ktor-server-typesafe-auth`. Users who want OpenID Connect add `ktor-server-auth-openid`. Each layer is independently useful.
 
 5. **`@KtorExperimental` provides a safe feedback period.**
 
 # Open Questions
-[open-questions]: #open-questions
 
 1. **How far should defaults go?** The OpenID Connect plugin can provide default URIs for redirect, login, logout, and refresh. Should these require explicit opt-in, or is it acceptable to provide sensible defaults? The design review leaned toward requiring explicit enabling for features like auto-refresh.
 
@@ -515,7 +524,6 @@ Since `ktor-server-auth-typesafe` is compiled with Kotlin 2.4.0, it uses context
 4. **`AuthRole` and `AuthScheme<T, R>` — interface vs sealed interface vs abstract class?** Both are currently interfaces. Should `AuthScheme<T, R>` be an abstract class to enable storing `KClass<T>` and `KClass<R>` tokens for reification, or is the interface sufficient?
 
 # Future Directions
-[future-directions]: #future-directions
 
 1. **Multi-provider federation.** Support multiple OpenID Connect providers (Google, GitHub, Apple) with a unified principal type and automatic provider selection based on the token's `iss` claim.
 

--- a/proposals/0006-auth-3.5.md
+++ b/proposals/0006-auth-3.5.md
@@ -1,0 +1,528 @@
+|             |                                                                                  |
+|-------------|----------------------------------------------------------------------------------|
+| Feature     | Typesafe Authentication & OpenID Connect Plugin                                  |
+| Submitted   | 2026-03-23                                                                       |
+| Accepted    | No                                                                               |
+| Issue       | https://youtrack.jetbrains.com/issue/KTOR-9266/Improve-Auth-in-Ktor              |
+| Preceded by |                                                                                  |
+| Followed by |                                                                                  |
+
+### Contents
+
+1. [Summary](#summary)
+2. [Motivation](#motivation)
+3. [Current Solutions](#current-solutions)
+4. [Design Overview](#design-overview)
+5. [Design Details](#design-details)
+6. [Technical Details](#technical-details)
+7. [Drawbacks](#drawbacks)
+8. [Advantages](#advantages)
+9. [Open Questions](#open-questions)
+10. [Future Directions](#future-directions)
+
+<hr />
+
+# Summary
+[summary]: #summary
+
+This proposal introduces role-based authorization in Ktor's core auth module, a typesafe authentication DSL with non-nullable principals, and a first-class OpenID Connect plugin for Ktor 3.5.0. Role support (`AuthRole`, `roles { }` extractor, `call.roles()`) is added directly to `ktor-server-auth` so it works with every authentication provider. The typesafe DSL (`requireAuth`, `optionalAuth`, `AuthScheme<T, R>`) is delivered as a separate `ktor-server-auth-typesafe` module of pure extension functions, compiled with Kotlin 2.4.0 for context parameters. Together these changes eliminate the most common boilerplate. All new APIs ship under `@KtorExperimental` to allow community feedback before stabilisation.
+
+# Motivation
+[motivation]: #motivation
+
+1. **No OpenID Connect support.**
+
+2. **Principals are always nullable (KTOR-8594).** Even inside a mandatory `authenticate { }` block, `call.principal<T>()` returns `T?`. This forces every route handler to perform a null check or `!!`, adding noise and masking the actual guarantee that the pipeline provides.
+
+3. **No built-in role/permission support.** Nearly every real application needs role-based access control.
+
+# Current Solutions
+[current-solutions]: #current-solutions
+
+### OpenID Connect
+
+Low-level API proposal https://github.com/ktorio/ktor/pull/5339:
+
+```kotlin
+val config = httpClient.fetchOpenIdConfiguration("https://accounts.google.com")
+install(Authentication) {
+    jwt {
+        validate { credential ->
+            val userId = credential.subject
+            database.findUser(userId)?.let { UserPrincipal(it) }
+        }
+        jwk {
+            openIdConfig = config
+            audience = "my-app-client-id"
+        }
+    }
+}
+```
+
+### Nullable Principals
+
+Even when authentication is mandatory, every handler must deal with nullability:
+
+```kotlin
+authenticate {
+    get("/profile") {
+        val principal = call.principal<UserPrincipal>()
+            ?: return@get call.respond(HttpStatusCode.Unauthorized)
+        // ... use principal
+    }
+}
+```
+
+# Design Overview
+[design-overview]: #design-overview
+
+This proposal addresses the pain points through three interconnected features:
+
+| Pain Point | Proposed Solution |
+|---|---|
+| No role support | `AuthRole` interface, `roles { }` extractor on every provider, `call.roles()` accessor — all in core `ktor-server-auth` |
+| Nullable principals | `requireAuth(scheme, roles) { }` routing DSL with non-null `principal()` and typed `roles()` via context parameters — in `ktor-server-auth-typesafe` |
+| OpenID Connect boilerplate | First-class `install(OpenIdConnect) { }` plugin with auto-discovery and sensible defaults — in `ktor-server-auth-openid` |
+
+All new APIs are annotated `@KtorExperimental`.
+
+# Design Details
+[design-details]: #design-details
+
+## 1. OpenID Connect Plugin
+
+### Minimal Setup (Resource Server)
+
+A resource server that only validates JWTs from an OpenID Connect provider:
+
+```kotlin
+install(OpenIdConnect) {
+    jwk(
+        issuer = "https://accounts.google.com",
+        audience = "my-app-client-id"
+    )
+}
+```
+
+The plugin automatically:
+- Fetches `/.well-known/openid-configuration` from the issuer
+- Configures a JWK provider from the discovered `jwks_uri`
+- Validates the issuer claim
+- Extracts standard OpenID Connect claims into `OpenIdConnectPrincipal`
+
+### Full Setup (Authorization Server with OAuth2 + Sessions)
+
+An application that also handles login/logout flows:
+
+```kotlin
+install(OpenIdConnect) {
+    jwk(
+        issuer = "https://accounts.google.com", 
+        audience = "my-app-client-id"
+    )
+    
+    oauth("https://accounts.google.com", clientId, clientSecret) {
+        scopes = listOf("openid", "profile", "email")
+        
+        // URI configuration — defaults are provided, override as needed
+        redirectUri { path("oidc", "redirect") }
+        loginUri { path("oidc", "login") }
+        logoutUri { path("oidc", "logout") }
+        
+        // Session configuration
+        session("OPENID_SESSION") {
+            cookie.secure = true
+            cookie.httpOnly = true
+            cookie.extensions["SameSite"] = "lax"
+        }
+        
+        // Lifecycle callbacks
+        onSuccess { principal ->
+            call.sessions.set(principal)
+            call.respondRedirect("/")
+        }
+        
+        onFailure {
+            call.respond(HttpStatusCode.Unauthorized)
+        }
+        
+        // Opt-in to token refresh
+        refresh {
+            refreshUri { path("oidc", "refresh") }
+            autoRefresh = true
+            refreshThresholdSeconds = 300
+        }
+    }
+}
+```
+
+### `OpenIdConnectPrincipal` and Claims
+
+`OpenIdConnectPrincipal` provides typed access to standard OpenID Connect claims:
+
+```kotlin
+@Serializable
+open class OpenIdConnectPrincipal(
+    val idToken: String,
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+    val userInfo: UserInfo,
+) {
+    @Serializable
+    class UserInfo(
+        val subject: String,
+        val name: String? = null,
+        val email: String? = null,
+        val emailVerified: Boolean? = null,
+        val picture: String? = null,
+        val givenName: String? = null,
+        val familyName: String? = null,
+        // ... other standard OIDC claims
+        val claims: Map<String, Any?> = emptyMap()
+    )
+}
+```
+
+Custom claims are accessible via a typed DSL:
+
+```kotlin
+fun OpenIdConnectPrincipal.customField(): Long? =
+    userInfo.claims.getTyped("x-custom-field")
+
+inline fun <reified T> Map<String, Any?>.getTyped(key: String): T? =
+    this[key] as? T
+```
+
+This replaces the current verbose `credential.payload.getClaim(...).let { ... }` pattern.
+
+### Auto-Discovery Lifecycle
+
+The OpenID Connect discovery call is made asynchronously during application startup.
+1. Launched in `Application.coroutineScope` at plugin install time
+2. Wait inside `ApplicationModulesLoaded` handler, fail before start
+
+The `HttpClient` used for discovery defaults to a preconfigured internal client, but can be overridden:
+
+```kotlin
+install(OpenIdConnect) {
+    httpClient = myCustomClient
+    // ...
+}
+```
+
+### Named Security Schemes
+
+Each provider is automatically named for OpenAPI compatibility:
+
+- JWK-only provider: `"google"` (derived from config key)
+- OAuth provider: `"google-oauth"`
+- Combined JWK + session: `"google-jwt"`
+
+Custom names can be provided:
+
+```kotlin
+jwk("https://accounts.google.com") {
+    name = "google-resource"
+    // ...
+}
+```
+
+## 2. Role-Based Authorization (`ktor-server-auth`)
+
+Role support is added directly to Ktor's core `ktor-server-auth` module, making it available to **all** authentication providers without additional dependencies.
+
+### `AuthRole` Interface
+
+Roles are modeled as an interface, allowing users to use enums, sealed classes, or any implementation:
+
+```kotlin
+interface AuthRole {
+    val name: String
+}
+```
+
+Typical usage with an enum:
+
+```kotlin
+enum class Role : AuthRole {
+    User, Admin, Moderator;
+}
+```
+
+### Role Extraction on Authentication Providers
+
+A `roles { }` function is added to `AuthenticationProvider.Config` — the base class for all providers. Every built-in and custom provider supports role extraction automatically:
+
+```kotlin
+install(Authentication) {
+    jwt("my-jwt") {
+        validate { credential -> UserPrincipal(credential.payload) }
+        roles { principal: UserPrincipal ->
+            principal.tokenRoles
+                .mapNotNull { name -> Role.entries.find { it.name == name } }
+                .toSet()
+        }
+    }
+
+    session<SessionUser>("web-session") {
+        validate { session -> session }
+        roles { principal: SessionUser ->
+            database.rolesFor(principal.id)
+        }
+    }
+
+    bearer("api-key") {
+        authenticate { credential -> ApiKeyPrincipal(credential.token) }
+        roles { principal: ApiKeyPrincipal ->
+            database.permissionsFor(principal.keyId)
+        }
+    }
+}
+```
+
+The extractor runs once after successful validation. The result is stored in the authentication context alongside the principal. If the extractor is not provided, roles are null.
+
+### `call.roles()` — Low-Level Accessor
+
+After authentication, resolved roles are available via `call.roles()`:
+
+```kotlin
+authenticate("my-jwt") {
+    get("/profile") {
+        val principal = call.principal<UserPrincipal>()  // T? (existing API, unchanged)
+        val roles = call.roles()                          // Set<AuthRole>? (new)
+    }
+}
+```
+
+## 3. Typesafe Authentication DSL (`ktor-server-auth-typesafe`)
+
+The typesafe DSL is delivered as a **separate module** `ktor-server-auth-typesafe` so it can be compiled with a newer Kotlin version. This module provides extension functions. It builds on top of the core `ktor-server-auth` APIs (`authenticate`, `call.principal<T>()`, `call.roles()`).
+
+### `AuthScheme<T, R>` — Typed Authentication Scheme
+
+Authentication schemes carry their principal type and role type as generic parameters. Both are defined once at scheme declaration and inferred at every call site:
+
+```kotlin
+interface AuthScheme<T : Any, R : AuthRole> {
+    val name: String
+}
+```
+
+Users define their schemes as objects:
+
+```kotlin
+object GoogleJwt : AuthScheme<OpenIdConnectPrincipal, Role> {
+    override val name = "google-jwt"
+}
+
+object ApiKey : AuthScheme<ApiKeyPrincipal, ApiPermission> {
+    override val name = "api-key"
+}
+```
+
+The `R` parameter ensures that `requireAuth(GoogleJwt, roles = listOf(Role.Admin))` is checked at compile time — passing an `ApiPermission` where `Role` is expected is a type error.
+
+### `requireAuth` — Non-Nullable Principal with Integrated Roles
+
+A single routing DSL function that guarantees a non-null principal and optionally enforces roles — eliminating the nesting of separate `authenticate` + `withRole` blocks:
+
+```kotlin
+routing {
+    // Scheme-based — principal type inferred from GoogleJwt
+    requireAuth(GoogleJwt) {
+        get("/dashboard") {
+            val principal: OpenIdConnectPrincipal = principal()  // non-null, type inferred from T
+            val userRoles: Set<Role> = roles()                   // typed to R, resolved by core extractor
+
+            if (Role.Admin in userRoles) {
+                call.respond(adminDashboard(principal))
+            } else {
+                call.respond(userDashboard(principal))
+            }
+        }
+    }
+
+    // Scheme-based + role gate — 403 if user lacks the role, no extra nesting
+    requireAuth(GoogleJwt, roles = listOf(Role.Admin, Role.Moderator)) {
+        put("/content/{id}/moderate") { /* ... */ }
+    }
+}
+```
+
+`requireAuth` internally:
+1. Wraps the route in `authenticate(...)` using the scheme name(s)
+2. Installs a route-scoped interceptor that extracts the principal and makes it available as non-null via Kotlin context parameters
+3. If roles are specified, checks `call.roles()` against the required set — responds 403 Forbidden on mismatch
+4. Returns 401 Unauthorized if authentication fails (configurable)
+
+### Signature Overloads
+
+```kotlin
+fun <T : Any, R : AuthRole> Route.requireAuth(
+    scheme: AuthScheme<T, R>,
+    roles: List<R> = emptyList(),
+    build: Route.() -> Unit
+): Route
+```
+
+### Principal and Roles via Context Parameters
+
+With context parameters, user-defined functions can access the principal and roles directly in scope:
+
+```kotlin
+context(principal: OpenIdConnectPrincipal, ctx: RoutingContext)
+suspend fun userProfile(): UserProfile {
+    return UserProfile(
+        name = principal.userInfo.name,
+        email = principal.userInfo.email
+    )
+}
+
+context(ctx: RoutingContext)
+suspend fun isAdmin(): Boolean =
+    Role.Admin in roles()
+```
+
+### Unauthorized Handler
+
+When a user lacks the required role, the server responds with 403 Forbidden by default. This is configurable:
+
+```kotlin
+requireAuth(GoogleJwt, roles = listOf(Role.Admin)) {
+    onUnauthorized { call, requiredRoles ->
+        call.respond(HttpStatusCode.Forbidden, "Requires: ${requiredRoles.joinToString()}")
+    }
+    get("/admin/users") { /* ... */ }
+}
+```
+
+The JWK provider checks (in order):
+1. `Authorization: Bearer <token>` header
+2. Session cookie with the configured name
+
+This supports both API clients (Bearer) and browser sessions (cookie) on the same endpoints. For OpenAPI documentation, both schemes are emitted under a single security requirement using an `OR` composition.
+
+# Technical Details
+[technical-details]: #technical-details
+
+## Module Structure
+
+The proposal spans three layers:
+
+- **`ktor-server-auth`** (existing module, extended) — `AuthRole` interface, `roles { }` extractor on `AuthenticationProvider.Config`, `call.roles()` accessor. Compiled with the same Kotlin version as Ktor core. All authentication providers gain role support with no additional dependencies.
+- **`ktor-server-auth-typesafe`** (new module) — `AuthScheme<T, R>`, `requireAuth`, `optionalAuth`, non-null `principal()`, typed `roles()` via context parameters. Compiled with a **newer Kotlin version** (targeting 2.4.0). This module is pure extension functions — no plugin install required. It depends on `ktor-server-auth` but not on `ktor-server-auth-openid`.
+- **`ktor-server-auth-openid`** (new module) — The OpenID Connect plugin. Compiled with the same Kotlin version as Ktor core. Configures JWK, OAuth, and session providers via the core `Authentication` plugin. Provides `withOidc` shorthand when `ktor-server-auth-typesafe` is also on the classpath.
+
+## Plugin Architecture
+
+The `OpenIdConnect` plugin is a standard Ktor `BaseApplicationPlugin` that internally:
+1. Launches async discovery for each issuer
+2. Registers JWK and OAuth authentication providers via the `Authentication` plugin
+3. If OAuth is configured, installs `Sessions` and sets up login/callback/refresh/logout routes
+
+## Core Role Extraction Implementation
+
+When `roles { }` is configured on an `AuthenticationProvider.Config`, the extractor runs immediately after a successful `validate` call. The resolved set is stored in the authentication context alongside the principal:
+
+```kotlin
+val ResolvedRolesKey = AttributeKey<Set<AuthRole>>("ResolvedRoles")
+```
+
+`call.roles()` reads from this attribute:
+
+```kotlin
+fun ApplicationCall.roles(): Set<AuthRole> =
+    attributes.getOrNull(ResolvedRolesKey) ?: emptySet()
+```
+
+This is part of `ktor-server-auth` and works in any `authenticate { }` block.
+
+## `requireAuth` Implementation
+
+`requireAuth` is a pure extension function in `ktor-server-auth-typesafe` that:
+1. Wraps the route in `authenticate(...)` using the scheme name(s)
+2. Installs a route-scoped interceptor that extracts the principal via `call.principal<T>()`
+3. If roles were specified, checks `call.roles()` against the required set (returns 403 on mismatch)
+4. Makes the principal available as a Kotlin context parameter
+
+A typesafe `roles()` accessor narrows the core `Set<AuthRole>` to the scheme's role type `R`:
+
+```kotlin
+context(principal: T, ctx: RoutingContext)
+@Suppress("UNCHECKED_CAST")
+fun <R : AuthRole> roles(): Set<R> = ctx.call.roles() as Set<R>
+```
+
+Since `ktor-server-auth-typesafe` is compiled with Kotlin 2.4.0, it uses context parameters directly — no fallback extension functions are needed.
+
+## Interaction with Existing APIs
+
+- `authenticate(...)` remains available for users who prefer the current API
+- `call.principal<T>()` continues to work (returns nullable)
+- `call.roles()` is new but returns an empty set if no `roles { }` extractor is configured, so existing code is unaffected
+- Existing `jwt { }`, `oauth { }`, `session { }` configurations are not affected — `roles { }` is optional
+- `OpenIdConnect` plugin internally uses these existing building blocks
+
+## Dependencies
+
+**`ktor-server-auth`** (existing, extended) — no new dependencies. `AuthRole` and `roles { }` are additions to the existing module.
+
+**`ktor-server-auth-typesafe`** depends on:
+- `ktor-server-auth` (for `call.principal<T>()`, `call.roles()`, `authenticate(...)`)
+- Kotlin 2.4.0+ (for context parameters)
+
+**`ktor-server-auth-openid`** depends on:
+- `ktor-server-auth` (existing)
+- `ktor-server-auth-jwt` (existing)
+- `ktor-server-sessions` (existing)
+- `ktor-client-core` (for discovery HTTP calls)
+- `ktor-client-content-negotiation` + `ktor-serialization-kotlinx-json` (for discovery deserialization)
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+1. **Increased surface area.** Adding `requireAuth`, `AuthScheme<T, R>`, and the `OpenIdConnect` plugin introduces new concepts alongside existing ones. Users must learn when to use `authenticate` vs `requireAuth`.
+
+2. **Implicit defaults may conflict with Ktor's philosophy.** The OpenID Connect plugin makes decisions about URI paths, session names, and cookie settings. While these are overridable, implicit behaviour can surprise users accustomed to Ktor's explicit style.
+
+3. **Separate module requires newer Kotlin version.** The `ktor-server-auth-typesafe` module requires context parameters.
+
+4. **Potential confusion with existing auth DSL.** Having both `authenticate { }` and `requireAuth { }` could confuse new users. Clear documentation and deprecation signals will be needed.
+
+# Advantages
+[advantages]: #advantages
+
+1. **Dramatically reduced boilerplate.** The OpenID Connect plugin reduces setup from 30+ lines of manual wiring to 5-10 lines. Typed principals eliminate null checks in every handler.
+
+2. **Enforces best practices.** Auto-discovery, httpOnly session cookies, secure defaults, and stateless JWT validation guide users toward secure implementations without requiring deep security knowledge.
+
+3. **Type safety prevents bugs.** Enum/interface-based roles catch typos at compile time. Non-null principals eliminate an entire class of runtime errors.
+
+4. **Composable, layered design.** Roles work with any provider via core `ktor-server-auth` alone. Users who want non-null principals add `ktor-server-auth-typesafe`. Users who want OpenID Connect add `ktor-server-auth-openid`. Each layer is independently useful.
+
+5. **`@KtorExperimental` provides a safe feedback period.**
+
+# Open Questions
+[open-questions]: #open-questions
+
+1. **How far should defaults go?** The OpenID Connect plugin can provide default URIs for redirect, login, logout, and refresh. Should these require explicit opt-in, or is it acceptable to provide sensible defaults? The design review leaned toward requiring explicit enabling for features like auto-refresh.
+
+2. **Session + Bearer in a single provider vs named providers.** The design review concluded that multiple named schemes are better for OpenAPI documentation. Should dual-auth be the default, or should it require explicit configuration?
+
+3. **Anonymous user support.** Should anonymous sessions be part of this proposal or deferred? Lazy session creation (to avoid Redis cost) and anonymous-to-authenticated transitions need more design work.
+
+4. **`AuthRole` and `AuthScheme<T, R>` — interface vs sealed interface vs abstract class?** Both are currently interfaces. Should `AuthScheme<T, R>` be an abstract class to enable storing `KClass<T>` and `KClass<R>` tokens for reification, or is the interface sufficient?
+
+# Future Directions
+[future-directions]: #future-directions
+
+1. **Multi-provider federation.** Support multiple OpenID Connect providers (Google, GitHub, Apple) with a unified principal type and automatic provider selection based on the token's `iss` claim.
+
+2. **Token refresh.** Automatic token refresh before expiry, configurable via the OpenID Connect plugin.
+
+3. **Anonymous user support.** Lazy anonymous sessions with smooth transition to authenticated sessions. This needs careful design around distributed session storage costs.
+
+4. **Scope-based authorization.** Extend the role-based system to support OAuth2 scopes, enabling fine-grained permission checks like `withScope("orders:read")`.
+
+5. **PKCE and advanced OAuth2 flows.** Support Proof Key for Code Exchange (PKCE) for public clients, device authorization grants, and other advanced OAuth2 flows within the OpenID Connect plugin.


### PR DESCRIPTION
The core idea is to encode more information in auth schemes at the type level — principal type, role model, and anonymous fallback, so the compiler enforces correctness across the entire auth pipeline.

This proposal presents two equal alternatives:

- Typesafe extension to the current system
- Typed provider DSL replacing the current one